### PR TITLE
Revert "Add the guide release date"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,6 @@
 :projectid: rest-client-java
 :page-layout: guide
 :page-duration: 20 minutes
-:page-date: 2017-10-04
 :page-description: Learn how to consume a RESTful web service
 :page-tags: ['REST', 'Client', 'Java', 'JAX-RS', 'JSON-P']
 :page-permalink: /guides/{projectid}


### PR DESCRIPTION
Reverts OpenLiberty/guide-rest-client-java#6

`page-date` is causing Jekyll build to break.  Another Asciidoctor attribute will be needed to replace `page-date`.  Until we have the new attribute, revert the introduction of `page-date`.