### PR TITLE
Update guide to use JSON-B instead of Jackson

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,6 @@ When the server is running, you can find your service at:
 // =================================================================================================
 // Guide
 // =================================================================================================
-
 == POJOs
 
 To deserialize a JSON message, start with creating Plain Old Java Objects (POJOs) that represent what
@@ -111,6 +110,19 @@ include::finish/src/main/java/io/openliberty/guides/consumingrest/model/Artist.j
 ----
 include::finish/src/main/java/io/openliberty/guides/consumingrest/model/Album.java[tags=!comment]
 ----
+
+== Differences between JSON-B and JSON-P
+
+With JSON-B you *directly* serialize and deserialize POJOs. This API gives you a
+variety of options for working with JSON resources.
+
+In contrast, you need to use helper methods with JSON-P to process the JSON response.
+This tactic is more straightforward, but it can be cumbersome with more complex classes.
+
+JSON-B is built on top of the existing JSON-P API. JSON-B can do everything that JSON-P can do
+and allows for more customization for serializing and deserializing. For
+more information on JSON-B and how to serialize POJOs into JSON strings please refer to the
+http://json-b.net/users-guide.html[JSON Binding 1.0 Users Guide].
 
 === Using JSON-B
 
@@ -268,7 +280,7 @@ For your test classes to have access to JSON-B, add the following dependency to 
 </dependency>
 ----
 
-Write the `testArtistDeserialization` test case.  This test checks that Artist instances created from
+Write the `testArtistDeserialization` test case. This test checks that `Artist` instances created from
 the REST data and those that are hardcoded perform the same.
 
 [source, java, indent = 0]
@@ -297,7 +309,7 @@ include::finish/src/test/java/it/io/openliberty/guides/consumingrest/ConsumingRe
 === Testing the processing with JSON-P
 
 Write the `testArtistCount` test case. This test checks that deserialization with JSON-P was done correctly
-and that the correct number of artist is returned.
+and that the correct number of artists is returned.
 
 [source, java, indent = 0]
 ----
@@ -341,25 +353,6 @@ Results :
 Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
 
 ----
-
-== Conclusions
-
-This guide solely focused on deserialization of JSON resources.  JSON-B provides the
-ability to *directly* serialize and deserialize POJOs.  This powerful API gives
-developers many options for working with JSON resources.
-
-In contrast, you may have noticed that the JSON-P implementation of this guide required
-the use of helper methods to process the JSON response.  This tactic is more
-straightforward, but can be cumbersome with more complex classes.
-
-After seeing these two ways to consume the returned JSON resources (JSON-B and JSON-P)
-from a RESTful web service you may be asking yourself, "Which way is better?"
-
-JSON-B was built on top of the existing JSON-P API.  It can do everything that JSON-P can
-and allows for more customization for serializing and deserializing.  We would recommend,
-if you have not already, to try using JSON-B for your next project.  If you want
-more information on JSON-B and how to serialize POJOs into JSON strings please refer to the
-http://json-b.net/users-guide.html[JSON Binding 1.0 Users Guide].
 
 == Great work! You're done!
 

--- a/README.adoc
+++ b/README.adoc
@@ -113,7 +113,7 @@ include::finish/src/main/java/io/openliberty/guides/consumingrest/model/Album.ja
 
 == Differences between JSON-B and JSON-P
 
-With JSON-B you *directly* serialize and deserialize POJOs. This API gives you a
+With JSON-B you directly serialize and deserialize POJOs. This API gives you a
 variety of options for working with JSON resources.
 
 In contrast, you need to use helper methods with JSON-P to process the JSON response.
@@ -121,7 +121,7 @@ This tactic is more straightforward, but it can be cumbersome with more complex 
 
 JSON-B is built on top of the existing JSON-P API. JSON-B can do everything that JSON-P can do
 and allows for more customization for serializing and deserializing. For
-more information on JSON-B and how to serialize POJOs into JSON strings please refer to the
+more information on JSON-B and how to serialize POJOs into JSON strings, refer to the
 http://json-b.net/users-guide.html[JSON Binding 1.0 Users Guide].
 
 === Using JSON-B

--- a/README.adoc
+++ b/README.adoc
@@ -124,17 +124,17 @@ find it useful to deserialize a JSON message with only certain properties, speci
 property names, or have a class with a custom constructor. In these cases,
 annotations are necessary and recommended:
 
-* The `@JsonProperty` annotation is used to map JSON keys to class instance members and vice versa.
+* The `@JsonbProperty` annotation is used to map JSON keys to class instance members and vice versa.
 Without the use of this annotation, JSON-B will attempt to do POJO mapping, matching the keys in
 the JSON to the class instance members by name. If these names do not match, then getters and setters
 are matched to JSON keys and the instance members are set explicitly. If the getter and setter
 signatures do not match any key names, then deserialization fails. Note that the `Artist` POJO,
 does not require this annotation since all instance members match the JSON keys by name.
 
-* The `@JsonbCreator` and `@JsonProperty` annotations are used to annotate a custom constructor.
+* The `@JsonbCreator` and `@JsonbProperty` annotations are used to annotate a custom constructor.
 This is required for proper parameter substitution when a custom constructor is used.
 
-* The `@JsonTransient` annotation is used to define an object property that does not map to any JSON
+* The `@JsonbTransient` annotation is used to define an object property that does not map to any JSON
 property. While the use of this annotation is good practice, it is only necessary for serialization.
 
 For more information on customization with JSON-B please see the
@@ -162,7 +162,7 @@ JSON-B is a Java API that is used to serialize Java objects to JSON messages and
 To include the JSON-B provider in your project, add the following dependency to your `pom.xml`,
 which has been done for you:
 
-[source, xml]
+[source, xml, role="no_copy"]
 ----
 <dependency>
    <groupId>javax.json.bind</groupId>
@@ -182,7 +182,7 @@ This method makes a `GET` request to the running artist service and retrieves th
 
 To bind the JSON into an `Artist` array, use the `Artist[]` entity type in the `readEntity` call:
 
-[source, java, indent = 0]
+[source, java, indent = 0, role="no_copy"]
 ----
 Artist[] artists = response.readEntity(Artist[].class);
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -25,11 +25,11 @@ Explore how to access a simple RESTful web service and consume its resources in 
 
 == What you'll learn
 
-You will learn how to access a REST service, serialize a java object containing a
-list of artists and their albums, and deserialize the returned JSON resources using
-two different approaches. The first approach consists of using JSON-B (binding) API
-to convert JSON messages into Java objects directly.  The second approach consists of
-using the JSON-P (JSON with Padding) API to process the JSON.
+You will learn how to access a REST service, serialize a Java object that contains a
+list of artists and their albums, and use two different approaches to deserialize
+the returned JSON resources. The first approach consists of using the JSON-B API
+to directly convert JSON messages into Java objects.  The second approach consists of
+using the JSON-P API to process the JSON.
 
 The REST service that provides the artists and albums resources has already been written
 for you and is accessible at:
@@ -114,30 +114,29 @@ include::finish/src/main/java/io/openliberty/guides/consumingrest/model/Album.ja
 
 === Using JSON-B
 
-JSON-B is a new feature introduced with Java EE 8 and strengthens Java's support for JSON.
-This guide previously used Jackson for JSON binding.  JSON-B requires, by default, a
-public default no-arguments constructor for deserialization.
+JSON-B is a feature introduced with Java EE 8 and strengthens Java support for JSON.
+By default, JSON-B requires a public default no-argument constructor for deserialization.
 
-The JSON-B engine includes a set of default mapping rules which can be run without
-any customization annotations or custom configuration. There are instances where you may
-find it useful to deserialize a JSON message with only certain properties, specific
-property names, or have a class with a custom constructor. In these cases,
+The JSON-B engine includes a set of default mapping rules, which can be run without
+any customization annotations or custom configuration. In some instances, you might
+find it useful to deserialize a JSON message with only certain fields, specific
+field names, or classes with custom constructors. In these cases,
 annotations are necessary and recommended:
 
-* The `@JsonbProperty` annotation is used to map JSON keys to class instance members and vice versa.
+* The `@JsonbProperty` annotation to map JSON keys to class instance members and vice versa.
 Without the use of this annotation, JSON-B will attempt to do POJO mapping, matching the keys in
 the JSON to the class instance members by name. If these names do not match, then getters and setters
 are matched to JSON keys and the instance members are set explicitly. If the getter and setter
 signatures do not match any key names, then deserialization fails. Note that the `Artist` POJO,
 does not require this annotation since all instance members match the JSON keys by name.
 
-* The `@JsonbCreator` and `@JsonbProperty` annotations are used to annotate a custom constructor.
-This is required for proper parameter substitution when a custom constructor is used.
+* The `@JsonbCreator` and `@JsonbProperty` annotations to annotate a custom constructor.
+This annotation is required for proper parameter substitution when a custom constructor is used.
 
-* The `@JsonbTransient` annotation is used to define an object property that does not map to any JSON
+* The `@JsonbTransient` annotation to define an object property that does not map to a JSON
 property. While the use of this annotation is good practice, it is only necessary for serialization.
 
-For more information on customization with JSON-B please see the
+For more information on customization with JSON-B, see the
 http://json-b.net/users-guide.html[JSON Binding 1.0 Users Guide].
 
 // =================================================================================================
@@ -159,8 +158,8 @@ include::finish/src/main/java/io/openliberty/guides/consumingrest/Consumer.java[
 
 JSON-B is a Java API that is used to serialize Java objects to JSON messages and vice versa.
 
-To include the JSON-B provider in your project, add the following dependency to your `pom.xml`,
-which has been done for you:
+To include the JSON-B provider in your project, add the following dependency to your `pom.xml`
+file, which is already done for you:
 
 [source, xml, role="no_copy"]
 ----
@@ -171,7 +170,7 @@ which has been done for you:
 </dependency>
 ----
 
-Write the method for consuming the REST service using JSON-B in the `Consumer` class:
+Use JSON-B in the `Consumer` class to write the method for consuming the REST service:
 
 [source, java, indent=0]
 ----
@@ -188,9 +187,9 @@ Artist[] artists = response.readEntity(Artist[].class);
 ----
 
 Write the `getJsonString` and `getTotalAlbums` methods in the `ArtistResource` class. The `getTotalAlbums`
-method will use JSON-B to return the total number of albums present in the JSON for a particular artist
-and -1 if this artist does not exist using JSON-B.  The `getJsonString` method will return the JSON as
-a string that we will use later for testing.
+method uses JSON-B to return the total number of albums present in the JSON for a particular artist. The
+method returns -1 if this artist does not exist. The `getJsonString` method returns the JSON as
+a string that will be used later for testing.
 
 `start/src/main/java/io/openliberty/guides/consumingrest/service/ArtistResource.java`:
 
@@ -209,8 +208,8 @@ Write the method for consuming the REST service using JSON-P in the `Consumer` c
 include::finish/src/main/java/io/openliberty/guides/consumingrest/Consumer.java[tags=consumeWithJsonp]
 ----
 
-Write the `collectArtists` and `collectAlbums` helpers. These methods will parse that JSON and
-collect its objects into individual POJOs.  Notice that we are able to use our custom constructors
+Write the `collectArtists` and `collectAlbums` helpers. These methods will parse the JSON and
+collect its objects into individual POJOs.  Notice that the you can use the custom constructors
 to create instances of `Artist` and `Album`:
 
 [source, java, indent=0]
@@ -228,11 +227,9 @@ approach to return the total number of artists present in the JSON.
 include::finish/src/main/java/io/openliberty/guides/consumingrest/service/ArtistResource.java[tags=getTotalArtists]
 ----
 
-It is worth noting that in this project the methods that we created in the `Consumer`
-class could be written directly in the `ArtistResource` class.  However, if you are
-consuming a REST resource from a third party service it is best practice to separate
-your GET and PULL requests from your data consumption.
-
+The methods that you created in the `Consumer` class can be written directly in the
+`ArtistResource` class. However, if you are consuming a REST resource from a third
+party service, you can separate your GET and PULL requests from your data consumption.
 
 // =================================================================================================
 // Testing deserialization
@@ -258,8 +255,8 @@ them via the `System.getProperty` call in the
 https://openliberty.io/guides/microprofile-intro.html[MicroProfile guide].
 
 === Testing the binding process
-In order for your test classes to have access to JSON-B you must add the following dependency to your `pom.xml`,
-which has been done for you:
+For your test classes to have access to JSON-B, add the following dependency to your
+`pom.xml` file, which is already done for you:
 
 [source, xml]
 ----

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -84,6 +84,26 @@
             <version>1.0.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -91,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.2.2</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>

--- a/finish/src/main/java/io/openliberty/guides/consumingrest/Consumer.java
+++ b/finish/src/main/java/io/openliberty/guides/consumingrest/Consumer.java
@@ -28,57 +28,57 @@ public class Consumer {
     // tag::class[]
     // tag::consumeWithJsonb[]
     public static Artist[] consumeWithJsonb(String targetUrl) {
-        Client client = ClientBuilder.newClient();
-        
-        Response response = client.target(targetUrl).request().get();
-        Artist[] artists = response.readEntity(Artist[].class);
-        
-        response.close();
-        client.close();
-        
-        return artists;
+      Client client = ClientBuilder.newClient();
+
+      Response response = client.target(targetUrl).request().get();
+      Artist[] artists = response.readEntity(Artist[].class);
+
+      response.close();
+      client.close();
+
+      return artists;
     }
     // end::consumeWithJsonb[]
-    
+
     // tag::consumeWithJsonp[]
     public static Artist[] consumeWithJsonp(String targetUrl) {
-        Client client = ClientBuilder.newClient();
-        
-        Response response = client.target(targetUrl).request().get();
-        JsonArray arr = response.readEntity(JsonArray.class);
-        
-        response.close();
-        client.close();
-        
-        return Consumer.collectArtists(arr);
+      Client client = ClientBuilder.newClient();
+
+      Response response = client.target(targetUrl).request().get();
+      JsonArray arr = response.readEntity(JsonArray.class);
+
+      response.close();
+      client.close();
+
+      return Consumer.collectArtists(arr);
     }
     // end::consumeWithJsonp[]
-    
+
     // tag::collectArtists[]
     private static Artist[] collectArtists(JsonArray artistArr) {
-        List<Artist> artists = artistArr.stream().map(artistJson -> { 
-        	JsonArray albumArr = ((JsonObject) artistJson).getJsonArray("albums");
-            Artist artist = new Artist(
-            		((JsonObject) artistJson).getString("name"),
-            		Consumer.collectAlbums(albumArr));
-            return artist;
-        }).collect(Collectors.toList());
-        
-        return artists.toArray(new Artist[artists.size()]);
+      List<Artist> artists = artistArr.stream().map(artistJson -> {
+        JsonArray albumArr = ((JsonObject) artistJson).getJsonArray("albums");
+        Artist artist = new Artist(
+          ((JsonObject) artistJson).getString("name"),
+          Consumer.collectAlbums(albumArr));
+        return artist;
+      }).collect(Collectors.toList());
+
+      return artists.toArray(new Artist[artists.size()]);
     }
     // end::collectArtists[]
-    
+
     // tag::collectAlbums[]
     private static Album[] collectAlbums(JsonArray albumArr) {
-        List<Album> albums = albumArr.stream().map(albumJson -> {
-            Album album = new Album(
-            		((JsonObject) albumJson).getString("title"),
-            		((JsonObject) albumJson).getString("artist"),
-            		((JsonObject) albumJson).getInt("ntracks") );
-            return album;
-        }).collect(Collectors.toList());
-        
-        return albums.toArray(new Album[albums.size()]);
+      List<Album> albums = albumArr.stream().map(albumJson -> {
+        Album album = new Album(
+          ((JsonObject) albumJson).getString("title"),
+          ((JsonObject) albumJson).getString("artist"),
+          ((JsonObject) albumJson).getInt("ntracks") );
+        return album;
+      }).collect(Collectors.toList());
+
+      return albums.toArray(new Album[albums.size()]);
     }
     // end::collectAlbums[]
     // end::class[]

--- a/finish/src/main/java/io/openliberty/guides/consumingrest/model/Album.java
+++ b/finish/src/main/java/io/openliberty/guides/consumingrest/model/Album.java
@@ -16,33 +16,32 @@ import javax.json.bind.annotation.JsonbCreator;
 import javax.json.bind.annotation.JsonbProperty;
 
 public class Album {
+    public String title;
 
-    public String title; 
-    
     @JsonbProperty("artist")
     public String artistName;
-    
-    @JsonbProperty("ntracks") 
+
+    @JsonbProperty("ntracks")
     public int totalTracks;
-    
+
     public Album() {
     	//default constructor can be defined
     }
-    
+
     @JsonbCreator
     public Album(
-    		@JsonbProperty("title") String title, 
-    		@JsonbProperty("artist") String artistName, 
-    		@JsonbProperty("ntracks") int totalTracks) {
+        @JsonbProperty("title") String title,
+        @JsonbProperty("artist") String artistName,
+        @JsonbProperty("ntracks") int totalTracks) {
     	//or custom constructor can be used
-    	this.title = title;
-    	this.artistName = artistName;
-    	this.totalTracks = totalTracks;
+      this.title = title;
+      this.artistName = artistName;
+      this.totalTracks = totalTracks;
     }
 
     @Override
     public String toString() {
-        return "Album titled " + title + " by " + artistName + " contains " + totalTracks + " tracks";
+      return "Album titled " + title + " by " + artistName + " contains " + totalTracks + " tracks";
     }
 
 }

--- a/finish/src/main/java/io/openliberty/guides/consumingrest/model/Artist.java
+++ b/finish/src/main/java/io/openliberty/guides/consumingrest/model/Artist.java
@@ -17,10 +17,9 @@ import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbTransient;
 
 public class Artist {
-    
     public String name;
     public Album albums[];
-    
+
     // does not map to anything
     @JsonbTransient
     public boolean legendary = true;
@@ -28,19 +27,19 @@ public class Artist {
     public Artist() {
     	//default constructor can be defined
     }
-    
+
     @JsonbCreator
     public Artist(
-    		@JsonbProperty("name") String name, 
-    		@JsonbProperty("albums") Album albums[]) {
+        @JsonbProperty("name") String name,
+        @JsonbProperty("albums") Album albums[]) {
     	//or custom constructor can be used
-    	this.name = name;
-    	this.albums = albums;
+      this.name = name;
+      this.albums = albums;
     }
-    
+
     @Override
     public String toString() {
-        return name + " wrote " + albums.length + " albums";
+      return name + " wrote " + albums.length + " albums";
     }
 
 }

--- a/finish/src/main/java/io/openliberty/guides/consumingrest/service/ArtistResource.java
+++ b/finish/src/main/java/io/openliberty/guides/consumingrest/service/ArtistResource.java
@@ -28,51 +28,50 @@ import io.openliberty.guides.consumingrest.Consumer;
 
 @Path("artists")
 public class ArtistResource {
-    
+
     @Context
     UriInfo uriInfo;
-    
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public JsonArray getArtists() {
     	return Reader.getArtists();
     }
-    
+
     // tag::getJsonString[]
     @GET
     @Path("jsonString")
     @Produces(MediaType.TEXT_PLAIN)
     public String getJsonString() {
-    	Jsonb jsonb = JsonbBuilder.create();
-    	
-    	Artist[] artists = Consumer.consumeWithJsonb(uriInfo.getBaseUri().toString() + "artists");
-    	String result = jsonb.toJson(artists);
-    	
-    	return result;
+      Jsonb jsonb = JsonbBuilder.create();
+
+      Artist[] artists = Consumer.consumeWithJsonb(uriInfo.getBaseUri().toString() + "artists");
+      String result = jsonb.toJson(artists);
+
+      return result;
     }
     // end::getJsonString[]
-    
+
     // tag::getTotalArtists[]
     @GET
     @Path("total")
     @Produces(MediaType.TEXT_PLAIN)
     public int getTotalArtists() {
-        return Consumer.consumeWithJsonp(uriInfo.getBaseUri().toString() + "artists").length;
+      return Consumer.consumeWithJsonp(uriInfo.getBaseUri().toString() + "artists").length;
     }
     // end::getTotalArtists[]
-    
     // tag::getTotalAlbums[]
     @GET
     @Path("total/{artist}")
     @Produces(MediaType.TEXT_PLAIN)
     public int getTotalAlbums(@PathParam("artist") String artist) {
-        Artist[] artists = Consumer.consumeWithJsonb(uriInfo.getBaseUri().toString() + "artists");
-        for (int i = 0; i < artists.length; i++) {
-            if (artists[i].name.equals(artist)) {
-            	return artists[i].albums.length;
-            }
+      Artist[] artists = Consumer.consumeWithJsonb(uriInfo.getBaseUri().toString() + "artists");
+      for (int i = 0; i < artists.length; i++) {
+        if (artists[i].name.equals(artist)) {
+          return artists[i].albums.length;
         }
-        return -1;
+      }
+      return -1;
     }
     // end::getTotalAlbums[]
 

--- a/finish/src/test/java/it/io/openliberty/guides/consumingrest/ConsumingRestTest.java
+++ b/finish/src/test/java/it/io/openliberty/guides/consumingrest/ConsumingRestTest.java
@@ -28,105 +28,104 @@ import org.junit.Test;
 import io.openliberty.guides.consumingrest.model.Artist;
 
 public class ConsumingRestTest {
-    
+
     private static String port;
     private static String baseUrl;
     private static String targetUrl;
-    
+
     private Client client;
     private Response response;
-    
     // tag::setup[]
     @BeforeClass
     public static void oneTimeSetup() {
-        port = System.getProperty("liberty.test.port");
-        baseUrl = "http://localhost:" + port + "/artists/";
-        targetUrl = baseUrl + "total/";
+      port = System.getProperty("liberty.test.port");
+      baseUrl = "http://localhost:" + port + "/artists/";
+      targetUrl = baseUrl + "total/";
     }
-    
+
     @Before
     public void setup() {
-        client = ClientBuilder.newClient();
+      client = ClientBuilder.newClient();
     }
-    
+
     @After
     public void teardown() {
-        client.close();
+      client.close();
     }
     // end::setup[]
-
+    
     // tag::tests[]
     // tag::testArtistDeserialization[]
     @Test
     public void testArtistDeserialization() {
-    	response = client.target(baseUrl + "jsonString").request().get();
-    	this.assertResponse(baseUrl + "jsonString", response);
-    	
-    	Jsonb jsonb = JsonbBuilder.create();
-    	
-    	String expectedString = "{\"name\":\"foo\",\"albums\":"
-    			+ "[{\"title\":\"album_one\",\"artist\":\"foo\",\"ntracks\":12}]}";
-    	Artist expected = jsonb.fromJson(expectedString, Artist.class);
-    	
-    	String actualString = response.readEntity(String.class);
-		Artist[] actual = jsonb.fromJson(actualString, Artist[].class);
-    	
-    	assertEquals("Expected names of artists does not match", expected.name, actual[0].name);
-    	
-    	response.close();
+      response = client.target(baseUrl + "jsonString").request().get();
+      this.assertResponse(baseUrl + "jsonString", response);
+
+      Jsonb jsonb = JsonbBuilder.create();
+
+      String expectedString = "{\"name\":\"foo\",\"albums\":"
+        + "[{\"title\":\"album_one\",\"artist\":\"foo\",\"ntracks\":12}]}";
+      Artist expected = jsonb.fromJson(expectedString, Artist.class);
+
+      String actualString = response.readEntity(String.class);
+		  Artist[] actual = jsonb.fromJson(actualString, Artist[].class);
+
+      assertEquals("Expected names of artists does not match", expected.name, actual[0].name);
+
+      response.close();
     }
     // end::testArtistDeserialization[]
-    
+
     // tag::testArtistCount[]
     @Test
     public void testArtistCount() {
-        response = client.target(targetUrl).request().get();
-        this.assertResponse(targetUrl, response);
-        
-        int expected = 3;
-        int actual = response.readEntity(int.class);
-        assertEquals("Expected number of artists does not match", expected, actual);
-        
-        response.close();
+      response = client.target(targetUrl).request().get();
+      this.assertResponse(targetUrl, response);
+
+      int expected = 3;
+      int actual = response.readEntity(int.class);
+      assertEquals("Expected number of artists does not match", expected, actual);
+
+      response.close();
     }
     // end::testArtistCount[]
-    
+
     // tag::testAlbumCount[]
     @Test
     public void testAlbumCount() {
-        String[] artists = {"dj", "bar", "foo"};
-        for (int i = 0; i < artists.length; i++) {
-            response = client.target(targetUrl + artists[i]).request().get();
-            this.assertResponse(targetUrl + artists[i], response);
-            
-            int expected = i;
-            int actual = response.readEntity(int.class);
-            assertEquals("Album count for " + artists[i] + " does not match", expected, actual);
-            
-            response.close();
-        }
+      String[] artists = {"dj", "bar", "foo"};
+      for (int i = 0; i < artists.length; i++) {
+        response = client.target(targetUrl + artists[i]).request().get();
+        this.assertResponse(targetUrl + artists[i], response);
+
+        int expected = i;
+        int actual = response.readEntity(int.class);
+        assertEquals("Album count for " + artists[i] + " does not match", expected, actual);
+
+        response.close();
+      }
     }
     // end::testAlbumCount[]
-    
+
     // tag::testAlbumCountForUnknownArtist[]
     @Test
     public void testAlbumCountForUnknownArtist() {
-        response = client.target(targetUrl + "unknown-artist").request().get();
-        
-        int expected = -1;
-        int actual = response.readEntity(int.class);
-        assertEquals("Unknown artist must have -1 albums", expected, actual);
-        
-        response.close();
+      response = client.target(targetUrl + "unknown-artist").request().get();
+
+      int expected = -1;
+      int actual = response.readEntity(int.class);
+      assertEquals("Unknown artist must have -1 albums", expected, actual);
+
+      response.close();
     }
     // end::testAlbumCountForUnknownArtist[]
-    
+
     /**
      * Asserts that the given URL has the correct (200) response code.
      */
     // tag::assertResponse[]
     private void assertResponse(String url, Response response) {
-        assertEquals("Incorrect response code from " + url, 200, response.getStatus());
+      assertEquals("Incorrect response code from " + url, 200, response.getStatus());
     }
     // end::assertResponse[]
     // end::tests[]

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -84,6 +84,26 @@
             <version>1.0.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -91,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.2.2</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <packagingExcludes>pom.xml</packagingExcludes>


### PR DESCRIPTION
Will not work until Java EE8 is released. Updating guide using JSON-B instead of Jackson.  Also using the newest version of JSON-P.