### PR TITLE
Use Liberty features for API dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -176,15 +176,16 @@ include::finish/src/main/java/io/openliberty/guides/consumingrest/Consumer.java[
 
 JSON-B is a Java API that is used to serialize Java objects to JSON messages and vice versa.
 
-To include the JSON-B provider in your project, add the following dependency to your `pom.xml`
+Open Liberty's `jsonb-1.0` feature on Maven Central includes the JSON-B provider through transitive dependencies. To include the JSON-B provider in your project, add the following dependency to your `pom.xml`
 file, which is already done for you:
 
 [source, xml, role="no_copy"]
 ----
 <dependency>
-   <groupId>javax.json.bind</groupId>
-   <artifactId>javax.json.bind-api</artifactId>
-   <version>1.0</version>
+   <groupId>io.openliberty.features</groupId>
+   <artifactId>jsonb-1.0</artifactId>
+   <type>esa</type>
+   <scope>provided</scope>
 </dependency>
 ----
 

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -20,7 +20,19 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
-     <dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>18.0.0.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -46,36 +58,23 @@
             <version>1.0.4</version>
             <scope>provided</scope>
         </dependency>
+        <!--  Open Liberty features -->
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.1</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-            <version>1.0.10</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- JSON-P API -->
-        <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.0</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonp-1.1</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.json</artifactId>
-            <version>1.0.10</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- JSON-B API -->
-        <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
-            <version>1.0</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonb-1.0</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -20,7 +20,19 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
-     <dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>18.0.0.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -46,36 +58,23 @@
             <version>1.0.4</version>
             <scope>provided</scope>
         </dependency>
+        <!--  Open Liberty features -->
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.1</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-            <version>1.0.10</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- JSON-P API -->
-        <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.0</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonp-1.1</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.json</artifactId>
-            <version>1.0.10</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- JSON-B API -->
-        <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
-            <version>1.0</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonb-1.0</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update the poms and JSON-B dependency example to use Liberty features to transitively provide API dependencies, instead of needing to directly depend on those APIs.  Another benefit is that you don't need to specify versions for the Liberty APIs such as 1.0.10.

For more info, see the Dependencies - Maven section of [this](https://openliberty.io/blog/2018/07/27/installing-features-from-maven-dependencies.html) post.