### PR TITLE
Added stop-server instruction

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,6 +86,8 @@ When the server is running, you can find your service at:
 
 * `http://localhost:9080/artists`
 
+include::{common-includes}/trywhatyoubuild-end.adoc[]
+
 // =================================================================================================
 // Guide
 // =================================================================================================


### PR DESCRIPTION
Added the 'mvn liberty:stop-server' instruction to the end of the 'Starting the Service' section to ensure users are able to re-install the service later in the guide. 