### PR TITLE
Use release bom, install features to kernel, change test dependency scopes

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>18.0.0.2</version>
+                <version>RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -43,20 +43,20 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-client</artifactId>
             <version>3.1.11</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-extension-providers</artifactId>
             <version>3.1.11</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <!-- JSON-P RI -->
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
             <version>1.0.4</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <!--  Open Liberty features -->
         <dependency>
@@ -118,11 +118,11 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
                 <configuration>
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
-                        <artifactId>openliberty-runtime</artifactId>
+                        <artifactId>openliberty-kernel</artifactId>
                         <version>RELEASE</version>
                         <type>zip</type>
                     </assemblyArtifact>
@@ -141,6 +141,18 @@
                         <goals>
                             <goal>install-server</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>install-feature</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <features>
+                                <acceptLicense>true</acceptLicense>
+                            </features>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>install-app</id>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>18.0.0.2</version>
+                <version>RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -43,20 +43,20 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-client</artifactId>
             <version>3.1.11</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-extension-providers</artifactId>
             <version>3.1.11</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <!-- JSON-P RI -->
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
             <version>1.0.4</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <!--  Open Liberty features -->
         <dependency>
@@ -118,11 +118,11 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
                 <configuration>
                     <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
-                        <artifactId>openliberty-runtime</artifactId>
+                        <artifactId>openliberty-kernel</artifactId>
                         <version>RELEASE</version>
                         <type>zip</type>
                     </assemblyArtifact>
@@ -141,6 +141,18 @@
                         <goals>
                             <goal>install-server</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>install-feature</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <features>
+                                <acceptLicense>true</acceptLicense>
+                            </features>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>install-app</id>


### PR DESCRIPTION
- Use `RELEASE` for the features bom version to match with the runtime assembly artifact version.
- Install features to `openliberty-kernel` instead of using the full runtime package.  This reduces download size.  (Need to use liberty-maven-plugin version 2.5 for this install functionality)
- Change some dependencies to `test` scope instead of `provided`, since they are only used during test runtime and not for compilation.