### PR TITLE
Remove extra options to stop dev mode

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -388,7 +388,7 @@ Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
 
 ----
 
-When you are done checking out the service, exit dev mode by typing `q` in the command-line session where you ran Liberty, and then press the `enter/return` key.
+When you are done checking out the service, exit dev mode by pressing `CTRL+C` in the command-line session where you ran Liberty.
 
 == Building the application
 


### PR DESCRIPTION
[Issue- https://github.com/OpenLiberty/guides-common/issues/866](https://github.com/OpenLiberty/guides-common/issues/866) : removed `q` and extra `liberty:stop`